### PR TITLE
fix bibliopraphy_path

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -47,7 +47,7 @@
 	// Path to your bibliography file
 	// You may use `.yml` for Hayagriva format
 	// or `.bib` for BibLaTeX format
-	bibliography_path: "literature.yaml",
+	bibliography_path: "literature.yml",
 
 	// The contents of your abstract
 	abstract: include "./abstract.typ",


### PR DESCRIPTION
Fixing this mismatch between the configured `literature.yaml` and provided `literature.yml` file.
This caused the preview to not render when importing the template as is.